### PR TITLE
Update to Whoops 2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
 	"license": "MIT",
 	"version": "1.0.0",
 	"require": {
-		"filp/whoops": "1.*",
+		"filp/whoops": "~2.0",
 		"composer/installers": "*"
 	}
 }


### PR DESCRIPTION
For reference, this appears to work in PHP 5.x and PHP 7.0, whereas whoops 1.x will not work properly with PHP 7.0. I've been running this in development for the past few months with no issues (excluding those referenced in other pull requests).

Re-opened from #14 because I accidentally deleted branch in my dev